### PR TITLE
Fix for hline when using mixed-pitch fonts in org tables.

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -357,6 +357,8 @@ Set to nil to disable the indicator."
            ;; Unique objects
            (sp1 (list 'space :width 1))
            (sp2 (list 'space :width 1))
+           (sp3 (list 'space :width 0.5))
+           (sp4 (list 'space :width 0.5))
            (color (face-attribute 'org-table :foreground nil t))
            (inner (progn
                     (goto-char beg)
@@ -384,6 +386,17 @@ Set to nil to disable the indicator."
         (when (numberp org-modern-table-horizontal)
           (add-face-text-property tbeg tend `(:overline ,color) 'append)
           (add-face-text-property beg (1+ end) `(:height ,org-modern-table-horizontal) 'append))
+
+        (when mixed-pitch-mode
+          ;; Initial search for start of 'hline
+          (re-search-forward "[^|+]+" tend 'noerror)
+          (let ((a (match-beginning 0))
+                (b (match-end 0)))
+            (cl-loop for i from a below b do
+                     (message "here %s a b" i a b)
+                     (put-text-property i (1+ i) 'display
+                                        (if (= 0 (mod i 2)) sp3 sp4)))))
+
         (while (re-search-forward "[^|+]+" tend 'noerror)
           (let ((a (match-beginning 0))
                 (b (match-end 0)))


### PR DESCRIPTION
I use mixed-pitch-mode to make text variable-pitch and table text fixed-pitch. This fixed an issue for me where org-table hlines were offset from the rest of the table due to a `(space :width 1)` property which was added to the leading spaces before the first `|` of the hline, while no space was added to the leading spaces before the first `|` in other table lines. Perhaps there is a better, more general fix, but this worked for me, so I thought I'd offer it as a fix for others.

Before fix:
![harrison-desktop-lin-2022-03-10-1646947957_screenshot_585x231](https://user-images.githubusercontent.com/13961671/157758251-b417fedd-0d58-4dd0-aab5-11978e1b1f67.jpg)

After fix:
![harrison-desktop-lin-2022-03-10-1646947932_screenshot_556x228](https://user-images.githubusercontent.com/13961671/157758244-a8c94534-b449-4873-8fe4-c9fc8431079a.jpg)

.