### PR TITLE
Fix missing dependency for when-let macro at compile time

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -35,6 +35,8 @@
 (require 'org)
 (eval-when-compile
   (require 'cl-lib))
+(eval-when-compile
+  (require 'subr-x))
 
 (defgroup org-modern nil
   "Modern looks for Org."


### PR DESCRIPTION
Using emacs 26.1 and straight.

when-let is a macro defined in subr-x.  straight compiles org-modern, and it appears subr-x hasn't been loaded when org-modern is compiled.  This leads to ```(when-let ...)``` being interpreted as a function, trying to evaluate (bullet ...) as a function, and failing with ```Symbol’s function definition is void: bullet```.

Add eval-when-compile/require to load subr-x at compile time.