### PR TITLE
Add support for per-keyword and per-block replacements

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -161,6 +161,10 @@ and faces in the cdr. Example:
   "Prettify blocks, wrapped by #+begin and #+end keywords."
   :type 'boolean)
 
+(defcustom org-modern-block-fringe t
+  "Add a bitmap fringe to blocks."
+  :type 'boolean)
+
 (defcustom org-modern-keyword t
   "Prettify keywords like #+title.
 If set to a string, e.g., \"‣\", the string is used as replacement for #+.
@@ -549,9 +553,10 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
         '(("^-\\{5,\\}$" 0 '(face org-modern-horizontal-rule display (space :width text)))))
       (when org-modern-table
         '(("^[ \t]*\\(|.*|\\)[ \t]*$" (0 (org-modern--table)))))
+      (when org-modern-block-fringe
+        '(("^[ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\S-" (0 (org-modern--block-fringe)))))
       (when org-modern-block
-        '(("^[ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\S-" (0 (org-modern--block-fringe)))
-          ("^\\([ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\)\\(\\S-+\\).*"
+        '(("^\\([ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\)\\(\\S-+\\).*"
            (1 '(face nil display (space :width (3))))
            (2 'org-modern-block-keyword append))
           ("^\\([ \t]*#\\+\\(?:end\\|END\\)_\\)\\(\\S-+\\).*"


### PR DESCRIPTION
These commits are motivated by my extensive use of `prettify-symbols-mode` in my own config. With them, per-keyword/block replacements are supported.

**Demo**

![image](https://user-images.githubusercontent.com/20903656/170955126-8c73c089-e6e4-4eb9-803e-1ddb13be3293.png)

**Demo config**
```elisp
  (setq org-modern-block
        '((default . t)
          ("src" "»" . "«")
          ("quote" "❝" . "❞")
          ("export" "⏩" . "⏪"))
        org-modern-keyword
        '((default . t)
          ("title" . "𝙏")
          ("subtitle" . "𝙩")
          ("author" . "𝘼")
          ("date" . "𝘿")
          ("property" . "☸")
          ("options" . "⌥")
          ("startup" . "⏻")
          ("macro" . "𝓜")
          ("bibliography" . "")
          ("print_bibliography" . "")
          ("html_head" . "🅷")
          ("html" . "🅗")
          ("latex_class" . "🄻")
          ("latex_header" . "🅻")
          ("latex" . "🅛")
          ("beamer_theme" . "🄱")
          ("beamer_header" . "🅱")
          ("beamer" . "🅑")
          ("attr_latex" . "🄛")
          ("attr_html" . "🄗")
          ("attr_org" . "⒪")
          ("name" . "⁍")
          ("header" . "›")
          ("caption" . "☰")
          ("RESULTS" . "🠶")))
```
