### PR TITLE
Don't swallow space after #+keyword:

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -292,7 +292,7 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
 (defun org-modern--keyword ()
   "Prettify keywords according to `org-modern-keyword'."
   (let ((beg (match-beginning 0))
-        (end (1+ (match-end 0)))
+        (end (match-end 0))
         (rep (assoc (match-string 2) org-modern-keyword)))
     (unless rep
       (setq rep (assq t org-modern-keyword) end (match-end 1)))


### PR DESCRIPTION
The final colon is part of the match, so `1+` takes us past the keyword.

Demos using `(setq org-modern-keyword '(("title" . "TT")))`.

Before this commit:

![image](https://user-images.githubusercontent.com/20903656/171912577-320ddc61-44bb-4a78-99c0-f7b4c40fd0a7.png)

After:

![image](https://user-images.githubusercontent.com/20903656/171912546-37c9724b-a4b7-4598-9a0d-ec7bfb89be5d.png)
