### PR TITLE
Add style to footnotes

### DIFF
--- a/example.org
+++ b/example.org
@@ -99,3 +99,8 @@ TREPEATED: <2022-02-26 Sat 10:00 .+1d/2d>
 <<This is an internal link>>
 
 [[This is an internal link]]
+
+* Footnotes
+[fn:1] Org-mode is a document thingx
+
+Org-modern makes your Org-mode[fn:1] documents look great

--- a/org-modern.el
+++ b/org-modern.el
@@ -178,6 +178,10 @@ used as replacement for \"#+keyword:\", with t the default key."
   "Prettify internal links, e.g., <<introduction>>."
   :type '(choice (const nil) (list string boolean string)))
 
+(defcustom org-modern-footnote t
+  "Prettify footnotes, e.g.: [fn:1]"
+  :type 'boolean)
+
 (defcustom org-modern-statistics t
   "Prettify todo statistics."
   :type 'boolean)
@@ -220,6 +224,10 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
 (defface org-modern-internal-link
   '((t :inherit org-modern-done))
   "Face used for internal link.")
+
+(defface org-modern-footnote
+  '((t :inherit org-footnote))
+  "Face used for footnote.")
 
 (defface org-modern-done
   '((default :inherit org-modern-label)
@@ -565,6 +573,12 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
            (3 '(face nil display ,(caddr org-modern-internal-link)))
            ,@(unless (cadr org-modern-internal-link)
               '((2 '(face nil invisible t)))))))
+      (when org-modern-footnote
+        '(("\\(\\[fn:\\)\\([0-9]\\{1,\\}+\\)\\(\\]\\)"
+           (0 '(face org-modern-footnote) t)
+           (1 '(face nil display " ("))
+           (3 '(face nil display ")"))
+           )))
       (when org-modern-timestamp
         '(("\\(?:<\\|\\[\\)\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}\\(?: [[:word:]]+\\)?\\(?: [.+-]+[0-9ymwdh/]+\\)*\\)\\(\\(?: [0-9:-]+\\)?\\(?: [.+-]+[0-9ymwdh/]+\\)*\\)\\(?:>\\|\\]\\)"
            (0 (org-modern--timestamp)))


### PR DESCRIPTION
Use `org-footnote` face by default and MLA style for punctuation. 

Would be great to make use of [superscripts](https://www.gnu.org/software/emacs/manual/html_node/org/Subscripts-and-Superscripts.html) for the footnotes, but simply adding `"^"` to the face does not trigger the pretty entities. Probably the superscript character needs to be inserted into the string. But I don't know how to do this! (Or if it is a great idea). So instead we settle for the [MLA](https://owl.purdue.edu/owl/research_and_citation/mla_style/mla_formatting_and_style_guide/mla_endnotes_and_footnotes.html) style of footnotes, which encloses the number inside of parenthesis. 

I'd like to give use the ability to customize the enclosure, choosing either parenthesis, square brackets, or curly braces. But I'm not sure how to get that to work.

``` elisp
(defcustom org-modern-footnote '("()")
  "Prettify footnotes, e.g.: [fn:1].
Set to nil to use default"  
  :type '(choice (const nil) (list string)))

;; keyword for footnote

      (when org-modern-footnote
        '(("\\(\\[fn:\\)\\([0-9]\\{1,\\}+\\)\\(\\]\\)"
           (0 '(face org-modern-footnote) t)
           (1 '(face nil display ,(substring (car org-modern-footnote) 0 1)))
           (3 '(face nil display ,(substring (car org-modern-footnote) 1 2)))
           )))
```

Oh, weird. I guess I pushed the commit with my work account. Ugh!