### PR TITLE
Block symbols

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -332,15 +332,17 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
                   (if (= 8 (length (match-string 2)))
                       (cadr rep) (caddr rep))
                 (cdr rep)))
-    (when org-modern-block-fringe
-      (put-text-property (match-beginning 1) beg 'invisible t))
     (cond
      ((eq rep 't)
-      (put-text-property beg beg-name 'invisible t)
+      (if org-modern-block-fringe
+          (put-text-property beg beg-name 'display '(space :width (3)))
+        (put-text-property beg beg-name 'invisible t))
       (add-face-text-property beg-name end 'org-modern-block-name))
      ((stringp rep)
       (put-text-property beg end-rep 'display
-                         (propertize rep 'face 'org-modern-symbol))))))
+                         (propertize rep 'face 'org-modern-symbol))
+      (when org-modern-block-fringe
+        (put-text-property (match-beginning 1) beg 'invisible t))))))
 
 (defun org-modern--checkbox ()
   "Prettify checkboxes according to `org-modern-checkbox'."
@@ -620,10 +622,15 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
            (0 (org-modern--block-fringe)))))
       (let* ((block-indent? (and org-modern-block-fringe '((1 '(face nil invisible t)))))
              (block-append '(3 'org-modern-block-name append))
+             (block-hide-simple
+              (append block-indent?
+                      (list (if org-modern-block-fringe
+                                '(2 '(face nil display (space :width (3))))
+                              '(2 '(face nil invisible t)))
+                            block-append)))
              (block-specs
               (cond ((eq org-modern-block-name t) ; hide
-                     `((,@block-indent? (2 '(face nil invisible t)) ,block-append) .
-                       (,@block-indent? (2 '(face nil invisible t)) ,block-append)))
+                     (cons block-hide-simple block-hide-simple))
                     ((and (consp org-modern-block-name) ; static replacement
                           (stringp (car org-modern-block-name)))
                      `((,@block-indent?

--- a/org-modern.el
+++ b/org-modern.el
@@ -320,18 +320,20 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
 
 (defun org-modern--block-name ()
   "Prettify block according to `org-modern-block-name'."
-  (let ((beg (match-beginning 1))
-        (beg-name (match-beginning 2))
-        (end (match-end 2))
-        (end-rep (match-end 2))
-        (rep (assoc (match-string 2) org-modern-block-name)))
+  (let ((beg (match-beginning 2))
+        (beg-name (match-beginning 3))
+        (end (match-end 3))
+        (end-rep (match-end 3))
+        (rep (assoc (match-string 3) org-modern-block-name)))
     (unless rep
       (setq rep (assq t org-modern-block-name)
             end-rep beg-name))
     (setq rep (if (consp (cdr rep))
-                  (if (= 8 (length (match-string 1)))
+                  (if (= 8 (length (match-string 2)))
                       (cadr rep) (caddr rep))
                 (cdr rep)))
+    (when org-modern-block-fringe
+      (put-text-property (match-beginning 1) beg 'invisible t))
     (cond
      ((eq rep 't)
       (put-text-property beg beg-name 'invisible t)
@@ -616,26 +618,28 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
       (when org-modern-block-fringe
         '(("^[ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\S-"
            (0 (org-modern--block-fringe)))))
-      (when-let ((block-specs
-                  (cond
-                   ((eq org-modern-block-name t) ; hide
-                    '(((1 '(face nil invisible t))
-                       (2 'org-modern-block-name append)) .
-                       ((1 '(face nil invisible t))
-                        (2 'org-modern-block-name append))))
-                   ((and (consp org-modern-block-name) ; static replacement
-                         (stringp (car org-modern-block-name)))
-                    `(((1 '(face nil display ,(car org-modern-block-name)))
-                       (2 'org-modern-block-name append)) .
-                       ((1 '(face nil display ,(cadr org-modern-block-name)))
-                        (2 'org-modern-block-name append))))
-                   ((and (consp org-modern-block-name) ; dynamic replacement
-                         (consp (car org-modern-block-name)))
-                    '(((0 (org-modern--block-name))) . ((0 (org-modern--block-name))))))))
-        `(("^[ \t]*\\(#\\+\\(?:begin\\|BEGIN\\)_\\)\\(\\S-+\\).*"
-           ,@(car block-specs))
-          ("^[ \t]*\\(#\\+\\(?:end\\|END\\)_\\)\\(\\S-+\\).*"
-           ,@(cdr block-specs))))
+      (let* ((block-indent? (and org-modern-block-fringe '((1 '(face nil invisible t)))))
+             (block-append '(3 'org-modern-block-name append))
+             (block-specs
+              (cond ((eq org-modern-block-name t) ; hide
+                     `((,@block-indent? (2 '(face nil invisible t)) ,block-append) .
+                       (,@block-indent? (2 '(face nil invisible t)) ,block-append)))
+                    ((and (consp org-modern-block-name) ; static replacement
+                          (stringp (car org-modern-block-name)))
+                     `((,@block-indent?
+                        (2 '(face nil display ,(car org-modern-block-name)))
+                        ,block-append) .
+                        (,@block-indent?
+                         (2 '(face nil display ,(cadr org-modern-block-name)))
+                         ,block-append)))
+                    ((and (consp org-modern-block-name) ; dynamic replacement
+                          (consp (car org-modern-block-name)))
+                     '(((0 (org-modern--block-name))) . ((0 (org-modern--block-name))))))))
+        (and block-specs
+             `(("^\\([ \t]*\\)\\(#\\+\\(?:begin\\|BEGIN\\)_\\)\\(\\S-+\\).*"
+                ,@(car block-specs))
+               ("^\\([ \t]*\\)\\(#\\+\\(?:end\\|END\\)_\\)\\(\\S-+\\).*"
+                ,@(cdr block-specs)))))
       (when org-modern-tag
         `((,(concat "^\\*+.*?\\( \\)\\(:\\(?:" org-tag-re ":\\)+\\)[ \t]*$")
            (0 (org-modern--tag)))))

--- a/org-modern.el
+++ b/org-modern.el
@@ -162,9 +162,23 @@ and faces in the cdr. Example:
   "Prettify tags in headlines, e.g., :tag1:tag2:."
   :type 'boolean)
 
-(defcustom org-modern-block t
-  "Prettify blocks, wrapped by #+begin and #+end keywords."
-  :type 'boolean)
+(defcustom org-modern-block-name t
+  "Prettify blocks names, i.e. #+begin_NAME and #+end_NAME lines.
+If set to a list of two strings, e.g. (\"‣\" \"‣\"), the strings are
+used as replacements for the #+begin_ and #+end_ prefixes, respectively.
+If set to an alist of block names and cons cells of strings, the associated
+strings will be used as a replacements for the whole of #+begin_NAME and
+#+end_NAME, respectively, and the association with t treated as the value for
+all other blocks."
+  :type '(choice (boolean :tag "Hide #+begin_ and #+end_ prefixes")
+                 (cons (string :tag "#+begin_ replacement")
+                       (string :tag "#+end_ replacement"))
+                 (const :tag "Triangle bullets" ("‣" . "‣"))
+                 (alist :key-type (choice (string :tag "Block")
+                                          (const :tag "Default" t))
+                        :value-type (choice (list (string :tag "#+begin_NAME replacement")
+                                                  (string :tag "#+end_NAME replacement"))
+                                            (boolean :tag "Hide #+begin_ and #+end_ prefixes")))))
 
 (defcustom org-modern-block-fringe t
   "Add a bitmap fringe to blocks."
@@ -227,7 +241,7 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
   `((t :height 0.9 :width condensed :weight regular :underline nil))
   "Parent face for labels.")
 
-(defface org-modern-block-keyword
+(defface org-modern-block-name
   '((t :height 0.8 :weight light))
   "Face used for block keywords.")
 
@@ -303,6 +317,28 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
 (defvar-local org-modern--star-cache nil)
 (defvar-local org-modern--checkbox-cache nil)
 (defvar-local org-modern--progress-cache nil)
+
+(defun org-modern--block-name ()
+  "Prettify block according to `org-modern-block-name'."
+  (let ((beg (match-beginning 1))
+        (beg-name (match-beginning 2))
+        (end (match-end 2))
+        (end-rep (match-end 2))
+        (rep (assoc (match-string 2) org-modern-block-name)))
+    (unless rep
+      (setq rep (assq t org-modern-block-name)
+            end-rep beg-name))
+    (setq rep (if (consp (cdr rep))
+                  (if (= 8 (length (match-string 1)))
+                      (cadr rep) (caddr rep))
+                (cdr rep)))
+    (cond
+     ((eq rep 't)
+      (put-text-property beg beg-name 'invisible t)
+      (add-face-text-property beg-name end 'org-modern-block-name))
+     ((stringp rep)
+      (put-text-property beg end-rep 'display
+                         (propertize rep 'face 'org-modern-symbol))))))
 
 (defun org-modern--checkbox ()
   "Prettify checkboxes according to `org-modern-checkbox'."
@@ -580,13 +616,26 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
       (when org-modern-block-fringe
         '(("^[ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\S-"
            (0 (org-modern--block-fringe)))))
-      (when org-modern-block
-        '(("^\\([ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\)\\(\\S-+\\)"
-           (1 '(face nil display (space :width (3))))
-           (2 'org-modern-block-keyword append))
-          ("^\\([ \t]*#\\+\\(?:end\\|END\\)_\\)\\(\\S-+\\)"
-           (1 '(face nil display (space :width (3))))
-           (2 'org-modern-block-keyword append))))
+      (when-let ((block-specs
+                  (cond
+                   ((eq org-modern-block-name t) ; hide
+                    '(((1 '(face nil invisible t))
+                       (2 'org-modern-block-name append)) .
+                       ((1 '(face nil invisible t))
+                        (2 'org-modern-block-name append))))
+                   ((and (consp org-modern-block-name) ; static replacement
+                         (stringp (car org-modern-block-name)))
+                    `(((1 '(face nil display ,(car org-modern-block-name)))
+                       (2 'org-modern-block-name append)) .
+                       ((1 '(face nil display ,(cadr org-modern-block-name)))
+                        (2 'org-modern-block-name append))))
+                   ((and (consp org-modern-block-name) ; dynamic replacement
+                         (consp (car org-modern-block-name)))
+                    '(((0 (org-modern--block-name))) . ((0 (org-modern--block-name))))))))
+        `(("^[ \t]*\\(#\\+\\(?:begin\\|BEGIN\\)_\\)\\(\\S-+\\).*"
+           ,@(car block-specs))
+          ("^[ \t]*\\(#\\+\\(?:end\\|END\\)_\\)\\(\\S-+\\).*"
+           ,@(cdr block-specs))))
       (when org-modern-tag
         `((,(concat "^\\*+.*?\\( \\)\\(:\\(?:" org-tag-re ":\\)+\\)[ \t]*$")
            (0 (org-modern--tag)))))

--- a/org-modern.el
+++ b/org-modern.el
@@ -324,7 +324,7 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
         (beg-name (match-beginning 3))
         (end (match-end 3))
         (end-rep (match-end 3))
-        (rep (assoc (match-string 3) org-modern-block-name)))
+        (rep (assoc (downcase (match-string 3)) org-modern-block-name)))
     (unless rep
       (setq rep (assq t org-modern-block-name)
             end-rep beg-name))

--- a/org-modern.el
+++ b/org-modern.el
@@ -166,6 +166,10 @@ and faces in the cdr. Example:
   "Prettify blocks, wrapped by #+begin and #+end keywords."
   :type 'boolean)
 
+(defcustom org-modern-block-fringe t
+  "Add a bitmap fringe to blocks."
+  :type 'boolean)
+
 (defcustom org-modern-keyword t
   "Prettify keywords like #+title.
 If set to t, the prefix #+ will be hidden.
@@ -573,10 +577,11 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
                      org-modern-horizontal-rule)))))
       (when org-modern-table
         '(("^[ \t]*\\(|.*|\\)[ \t]*$" (0 (org-modern--table)))))
-      (when org-modern-block
+      (when org-modern-block-fringe
         '(("^[ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\S-"
-           (0 (org-modern--block-fringe)))
-          ("^\\([ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\)\\(\\S-+\\)"
+           (0 (org-modern--block-fringe)))))
+      (when org-modern-block
+        '(("^\\([ \t]*#\\+\\(?:begin\\|BEGIN\\)_\\)\\(\\S-+\\)"
            (1 '(face nil display (space :width (3))))
            (2 'org-modern-block-keyword append))
           ("^\\([ \t]*#\\+\\(?:end\\|END\\)_\\)\\(\\S-+\\)"


### PR DESCRIPTION
I suppose this is the third attempt at block name replacement akin to the support introduced for keywords.

Replaces #84, which itself replaced #80, which succeeds #54.

See #80 for screenshots.