### PR TITLE
modify org-modern-timestamp regex to match French short date style

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -676,7 +676,7 @@ You can specify a font `:family'. The font families `Iosevka', `Hack' and
               ,@(unless (cadr org-modern-radio-target)
                   '((2 '(face nil invisible t)))))))))
       (when org-modern-timestamp
-        '(("\\(?:<\\|\\[\\)\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}\\(?: [[:word:]]+\\)?\\(?: [.+-]+[0-9ymwdh/]+\\)*\\)\\(\\(?: [0-9:-]+\\)?\\(?: [.+-]+[0-9ymwdh/]+\\)*\\)\\(?:>\\|\\]\\)"
+        '(("\\(?:<\\|\\[\\)\\([0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}\\(?: [[:word:]]+\\.?\\)?\\(?: [.+-]+[0-9ymwdh/]+\\)*\\)\\(\\(?: [0-9:-]+\\)?\\(?: [.+-]+[0-9ymwdh/]+\\)*\\)\\(?:>\\|\\]\\)"
            (0 (org-modern--timestamp)))
           ("<[^>]+>\\(-\\)\\(-\\)<[^>]+>\\|\\[[^]]+\\]\\(?1:-\\)\\(?2:-\\)\\[[^]]+\\]"
            (1 '(face org-modern-label display #("  " 1 2 (face (:strike-through t) cursor t))) t)


### PR DESCRIPTION
Org-modern was matching for dates like this:
<2022-09-11 mon>
<2022-09-11 mon 10:02:00>
But was not matching for French, short day-of-week dotted-style like this. Which resulted in not formatting dates and timestamps:
<2022-09-11 lun.>
<2022-09-11 lun. 10:02:00>
This short modification should fix this behavior.