### PR TITLE
Allowing different representations to "hidestar" in org heading

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -292,6 +292,9 @@ the font.")
 
 (defvar-local org-modern--font-lock-keywords nil)
 (defvar-local org-modern--star-cache nil)
+;;  Cache for hidestar, they are a cons pair of copy of the hidestar
+;;  string, propertized with `org-modern-symbol'.
+(defvar-local org-modern--hidestar-cache nil)
 (defvar-local org-modern--checkbox-cache nil)
 (defvar-local org-modern--progress-cache nil)
 (defvar-local org-modern--table-sp-width 0)
@@ -417,14 +420,13 @@ the font.")
         (end (match-end 1)))
     ;; leading hideStar
     (unless (eq beg end)
-      (cl-loop for p = beg then p+1
-               for p+1 = (1+ p)
-               until (= p end)
-               ;; gen new str
-               ;; for str = (concat org-modern-hide-stars)
-               ;; do (put-text-property p (1+ p) 'display str)
-               do (compose-region p p+1 org-modern-hide-stars)
-               ))
+	  (cl-flet ((put-stars
+				 (str beg end)
+				 (cl-loop for p = beg then (+ p 2)
+						  until (>= p end)
+						  do (put-text-property p (1+ p) 'display str))))
+		(put-stars (car org-modern--hidestar-cache) beg end)
+		(put-stars (cdr org-modern--hidestar-cache) (1+ beg) end)))
     ;; tail star
     (when org-modern-star
       (let ((level (- end beg)))
@@ -704,6 +706,12 @@ the font.")
      (vconcat (mapcar
                (lambda (x) (propertize x 'face 'org-modern-symbol))
                org-modern-star))
+	 org-modern--hidestar-cache
+	 (and (stringp org-modern-hide-stars)
+		  (cons (propertize (concat org-modern-hide-stars) 'face
+							'org-modern-symbol)
+				(propertize (concat org-modern-hide-stars) 'face
+							'org-modern-symbol)))
      org-modern--progress-cache
      (vconcat (mapcar
                (lambda (x) (concat " " (propertize x 'face 'org-modern-symbol) " "))

--- a/org-modern.el
+++ b/org-modern.el
@@ -56,6 +56,7 @@ Set to nil to disable styling the headlines."
 (defcustom org-modern-hide-stars 'leading
   "Make some of the headline stars invisible."
   :type '(choice
+          char
           (const :tag "Do not hide stars" nil)
           (const :tag "Hide all stars" t)
           (const :tag "Hide leading stars" leading)))
@@ -316,6 +317,14 @@ the font.")
       ('t (put-text-property beg (match-end 1) 'invisible t))
       ((pred stringp)
        (put-text-property beg end 'display rep)))))
+
+(defun org-modern--heading-hidestar ()
+  "Prettify headline leading with hidestar character."
+  (let ((beg (match-beginning 1))
+        (end (match-end 1)))
+    (put-text-property beg end 'display
+                       (make-string (- end beg)
+                                    org-modern-hide-stars))))
 
 (defun org-modern--progress ()
   "Prettify headline todo progress."
@@ -584,7 +593,8 @@ the font.")
      `(("^\\(\\**\\)\\(\\*\\) "
         ,@(and (not (eq org-modern-hide-stars t)) org-modern-star '((0 (org-modern--star))))
         ,@(and (eq org-modern-hide-stars 'leading) '((1 '(face nil invisible t))))
-        ,@(and (eq org-modern-hide-stars t) '((0 '(face nil invisible t)))))))
+        ,@(and (eq org-modern-hide-stars t) '((0 '(face nil invisible t))))
+        ,@(and (characterp org-modern-hide-stars) `((0 (org-modern--heading-hidestar)))))))
    (when org-modern-horizontal-rule
      `(("^[ \t]*-\\{5,\\}$" 0
         '(face org-modern-horizontal-rule display

--- a/org-modern.el
+++ b/org-modern.el
@@ -321,10 +321,13 @@ the font.")
 (defun org-modern--heading-hidestar ()
   "Prettify headline leading with hidestar character."
   (let ((beg (match-beginning 1))
-        (end (match-end 1)))
-    (put-text-property beg end 'display
-                       (make-string (- end beg)
-                                    org-modern-hide-stars))))
+        (end (match-end 1))
+        (acc ""))
+    (if (stringp org-modern-hide-stars)
+        (dotimes (_i (- end beg))
+          (setq acc (concat acc org-modern-hide-stars)))
+      (setq acc (make-string (- end beg) org-modern-hide-stars)))
+    (put-text-property beg end 'display acc)))
 
 (defun org-modern--progress ()
   "Prettify headline todo progress."
@@ -594,7 +597,8 @@ the font.")
         ,@(and (not (eq org-modern-hide-stars t)) org-modern-star '((0 (org-modern--star))))
         ,@(and (eq org-modern-hide-stars 'leading) '((1 '(face nil invisible t))))
         ,@(and (eq org-modern-hide-stars t) '((0 '(face nil invisible t))))
-        ,@(and (characterp org-modern-hide-stars) `((0 (org-modern--heading-hidestar)))))))
+        ,@(and (or (stringp org-modern-hide-stars) (characterp org-modern-hide-stars))
+			   `((0 (org-modern--heading-hidestar)))))))
    (when org-modern-horizontal-rule
      `(("^[ \t]*-\\{5,\\}$" 0
         '(face org-modern-horizontal-rule display


### PR DESCRIPTION
This is a PR that addresses a feature request made by me (https://github.com/minad/org-modern/issues/96#issuecomment-1276395109).

The scope of this PR is to add support for org-modern-hidestar, to use either string or char to replace each leading org heading stars.

Please advise on further actions.