### PR TITLE
Make org-modern-progress symbols consistent

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -234,7 +234,7 @@ references."
   "Prettify todo statistics."
   :type 'boolean)
 
-(defcustom org-modern-progress '("○" "◔" "◐" "◕" "●")
+(defcustom org-modern-progress '("○" "◔" "◑" "◕" "●")
   "Add a progress indicator to the todo statistics.
 Set to nil to disable the indicator."
   :type '(repeat string))


### PR DESCRIPTION
The default `org-modern-progress` is `("○" "◔" "◐" "◕" "●")`. Note the third symbol was shaded on the left half. This is inconsistent from what to expect from the neighboring symbols. When I noticed this inconsistency, it became extremely jarring and rendered the feature completely unusable to me (/s).

Thanks for this wonderful package :)