### PR TITLE
Remove compat dependency

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -33,7 +33,6 @@
 
 ;;; Code:
 
-(require 'compat)
 (require 'org)
 (eval-when-compile
   (require 'cl-lib)


### PR DESCRIPTION
It clones the entirety of elpa and really isn't necessary in this day and age. What's more, users of Emacs <=24 would have compat installed anyway by this point.