### PR TITLE
Use only broadly compatible symbols

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -61,12 +61,12 @@ Can be nil, fold or replace.  See `org-modern-fold-stars' and
                  (const :tag "Folding indicators" fold)
                  (const :tag "Replace" replace)))
 
-(defcustom org-modern-replace-stars "◉○◈◇✳"
+(defcustom org-modern-replace-stars "◉○◈◇"
   "Replacement strings for headline stars for each level."
   :type '(choice string (repeat string)))
 
 (defcustom org-modern-fold-stars
-  '(("▶" . "▼") ("▷" . "▽") ("⯈" . "⯆") ("▹" . "▿") ("▸" . "▾"))
+  '(("▶" . "▼") ("▷" . "▽") ("▹" . "▿") ("▸" . "▾"))
   "Folding indicators for headings.
 Replace headings' stars with an indicator showing whether its
 tree is folded or expanded."


### PR DESCRIPTION
In my Emacs setup at least, with Source Code Po as the main font, these two symbols are not available and Emacs ends up using Google Noto to render the caret (which is much larger and screws with line height) and an emoji font for the asterisk (which... clashes. It definitely clashes).

Maybe I'm the only one with these issues or you just like the default config the way it is: feel free to ignore this request. Thanks either way!