### PR TITLE
Set which-func-cleanup-function to fix mode line display

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -856,7 +856,8 @@ whole buffer; otherwise, for the line at point."
     (when (eq org-modern-star 'fold)
       (add-hook 'org-cycle-hook #'org-modern--cycle nil 'local))
     (org-modern--update-label-face)
-    (org-modern--update-fringe-bitmaps))
+    (org-modern--update-fringe-bitmaps)
+    (setq-local which-func-cleanup-function #'substring-no-properties))
    (t
     (remove-from-invisibility-spec 'org-modern)
     (font-lock-remove-keywords nil org-modern--font-lock-keywords)


### PR DESCRIPTION
Without this, `which-function` in org buffers returns a string with
many text properties, in particular the `display` property, which
causes the name of the current heading in to be rendered incorrectly
in the mode line.

I didn't bother to implement something "undoing" this when disabling
the mode, since it's not likely to be robust in the face of anything
else that sets which-func-cleanup-function (although then again,
neither is enabling it in the minor mode with setq-local).---Happy to add this if you prefer I do so.