### PR TITLE
Prepend org-modern faces to text properties

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -407,8 +407,8 @@ the font.")
         (put-text-property beg end 'display rep)
       (put-text-property beg (1+ beg) 'display " ")
       (put-text-property (1- end) end 'display " ")
-      (put-text-property
-       beg end 'face
+      (add-face-text-property
+       beg end
        (if-let ((face (or (cdr (assq prio org-modern-priority-faces))
                           (cdr (assq t org-modern-priority-faces)))))
            `(:inherit (,face org-modern-label))
@@ -432,9 +432,9 @@ the font.")
          (bar (concat (make-string w1 ?\s)
                       (buffer-substring-no-properties (1+ beg) (1- end))
                       (make-string (- w w1 w0) ?\s))))
-    (put-text-property 0 complete 'face 'org-modern-progress-complete bar)
-    (put-text-property complete w 'face 'org-modern-progress-incomplete bar)
-    (put-text-property beg end 'face 'org-modern-label)
+    (add-face-text-property 0 complete 'org-modern-progress-complete nil bar)
+    (add-face-text-property complete w 'org-modern-progress-incomplete nil bar)
+    (add-face-text-property beg end 'org-modern-label)
     (put-text-property beg (1+ beg) 'display (substring bar 0 w1))
     (put-text-property (1- end) end 'display (substring bar (+ w1 w0) w))
     (dotimes (i w0)
@@ -444,9 +444,7 @@ the font.")
 (defun org-modern--tag ()
   "Prettify headline tags."
   (save-excursion
-    (let* ((default-face (get-text-property (match-beginning 1) 'face))
-           (colon-props `(display #(":" 0 1 (face org-hide)) face ,default-face))
-           (beg (match-beginning 2))
+    (let* ((beg (match-beginning 2))
            (end (match-end 2))
            colon-beg colon-end)
       (goto-char beg)
@@ -458,14 +456,14 @@ the font.")
                                (format #(" %c" 1 3 (cursor t)) (char-after colon-end)))
             (put-text-property (1- cbeg) cbeg 'display
                                (string (char-before cbeg) ?\s))
-            (put-text-property
-             colon-end cbeg 'face
+            (add-face-text-property
+             colon-end cbeg
              (if-let ((faces org-modern-tag-faces)
                       (face (or (cdr (assoc (buffer-substring-no-properties colon-end cbeg) faces))
                                 (cdr (assq t faces)))))
                  `(:inherit (,face org-modern-tag))
                'org-modern-tag)))
-          (add-text-properties cbeg cend colon-props)
+	  (add-face-text-property cbeg cend 'org-hide)
           (setq colon-beg cbeg colon-end cend))))))
 
 (defun org-modern--todo ()
@@ -476,8 +474,8 @@ the font.")
     (put-text-property beg (1+ beg) 'display
                        (format #(" %c" 1 3 (cursor t)) (char-after beg)))
     (put-text-property (1- end) end 'display (string (char-before end) ?\s))
-    (put-text-property
-     beg end 'face
+    (add-face-text-property
+     beg end
      (if-let ((face (or (cdr (assoc todo org-modern-todo-faces))
                         (cdr (assq t org-modern-todo-faces)))))
          `(:inherit (,face org-modern-label))
@@ -509,20 +507,23 @@ the font.")
                (time-str (format-time-string (cdr fmt) time)))
           ;; year-month-day
           (add-text-properties beg (if (eq tbeg tend) end tbeg)
-                               `(face ,date-face display ,date-str))
+                               `(display ,date-str))
+	  (add-face-text-property beg (if (eq tbeg tend) end tbeg)
+				  date-face)
           ;; hour:minute
           (unless (eq tbeg tend)
             (add-text-properties tbeg end
-                                 `(face ,time-face display ,time-str))))
+                                 `(display ,time-str))
+	    (add-face-text-property tbeg end time-face)))
       (put-text-property beg (1+ beg) 'display " ")
       (put-text-property (1- end) end 'display " ")
       ;; year-month-day
-      (put-text-property beg (if (eq tbeg tend) end tbeg) 'face date-face)
+      (add-face-text-property beg (if (eq tbeg tend) end tbeg) date-face)
       ;; hour:minute
       (unless (eq tbeg tend)
         (put-text-property (1- tbeg) tbeg 'display
                            (string (char-before tbeg) ?\s))
-        (put-text-property tbeg end 'face time-face)))))
+        (add-face-text-property tbeg end time-face)))))
 
 (defun org-modern--star ()
   "Prettify headline stars."


### PR DESCRIPTION
This patch changes how org-modern applies faces to its elements. Instead of using `put-text-property` to set faces, this patch prepends faces with `add-face-text-property`. This allows themes to set default behaviors which are overridden by org-modern. In particular, overlines will correctly span over org-modern elements.

Behavior before:
![image](https://github.com/user-attachments/assets/61911ecf-8a81-4e97-bd64-65103c11e0b0)

Behavior after:
![image](https://github.com/user-attachments/assets/6ce73bc0-5e27-47fa-9429-996f955610ac)

Full config using elpaca:
```
(defvar elpaca-installer-version 0.8)
(defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
(defvar elpaca-repos-directory (expand-file-name "repos/" elpaca-directory))
(defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
                              :ref nil :depth 1
                              :files (:defaults "elpaca-test.el" (:exclude "extensions"))
                              :build (:not elpaca--activate-package)))
(let* ((repo  (expand-file-name "elpaca/" elpaca-repos-directory))
       (build (expand-file-name "elpaca/" elpaca-builds-directory))
       (order (cdr elpaca-order))
       (default-directory repo))
  (add-to-list 'load-path (if (file-exists-p build) build repo))
  (unless (file-exists-p repo)
    (make-directory repo t)
    (when (< emacs-major-version 28) (require 'subr-x))
    (condition-case-unless-debug err
        (if-let* ((buffer (pop-to-buffer-same-window "*elpaca-bootstrap*"))
                  ((zerop (apply #'call-process `("git" nil ,buffer t "clone"
                                                  ,@(when-let* ((depth (plist-get order :depth)))
                                                      (list (format "--depth=%d" depth) "--no-single-branch"))
                                                  ,(plist-get order :repo) ,repo))))
                  ((zerop (call-process "git" nil buffer t "checkout"
                                        (or (plist-get order :ref) "--"))))
                  (emacs (concat invocation-directory invocation-name))
                  ((zerop (call-process emacs nil buffer nil "-Q" "-L" "." "--batch"
                                        "--eval" "(byte-recompile-directory \".\" 0 'force)")))
                  ((require 'elpaca))
                  ((elpaca-generate-autoloads "elpaca" repo)))
            (progn (message "%s" (buffer-string)) (kill-buffer buffer))
          (error "%s" (with-current-buffer buffer (buffer-string))))
      ((error) (warn "%s" err) (delete-directory repo 'recursive))))
  (unless (require 'elpaca-autoloads nil t)
    (require 'elpaca)
    (elpaca-generate-autoloads "elpaca" repo)
    (load "./elpaca-autoloads")))
(add-hook 'after-init-hook #'elpaca-process-queues)
(elpaca `(,@elpaca-order))

(elpaca use-package)

;; Install use-package support
(elpaca elpaca-use-package
  ;; Enable :ensure use-package keyword.
  (elpaca-use-package-mode)
  ;; Assume :ensure t unless otherwise specified.
  (setq use-package-always-ensure t))

;; Block until current queue processed.
(elpaca-wait)

(use-package modus-themes
:config
  ;; Configure the Modus Themes' appearance
(setq modus-themes-mode-line '(accented borderless)
      modus-themes-bold-constructs t
      modus-themes-italic-constructs t
      modus-themes-fringes 'subtle
      modus-themes-tabs-accented t
      modus-themes-paren-match '(bold intense)
      modus-themes-prompts '(bold intense)
      ;modus-themes-completions 'opinionated
      modus-themes-org-blocks 'tinted-background
      modus-themes-scale-headings t
      modus-themes-region '(bg-only)
      modus-themes-headings
      '((1 . (rainbow overline background 1.4))
        (2 . (rainbow background 1.3))
        (3 . (rainbow bold 1.2))
	(t . (semilight 1.1))))

(setq modus-themes-common-palette-overrides
      modus-themes-preset-overrides-intense)

(setq modus-themes-scale-headings t)
(setq modus-themes-mixed-fonts t)

;; Load the dark theme by default
(load-theme 'modus-vivendi t)
)

(use-package org-modern
  :hook
  (org-mode . org-modern-mode)
  (org-agenda-finalize . org-modern-agenda)
  :ensure
  (org-modern
   :type git
   :repo "~/org-modern"
   :branch "add-face-text-property")

  :config
  (setq
   ;; Edit settings
   org-auto-align-tags nil
   org-tags-column 0
   org-catch-invisible-edits 'show-and-error
   org-special-ctrl-a/e t
   org-insert-heading-respect-content t

   ;; Org styling, hide markup etc.
   org-hide-emphasis-markers t
   org-pretty-entities t
   org-ellipsis "…"

   ;; Agenda styling
   org-agenda-tags-column 0
   org-agenda-block-separator ?─
   org-agenda-time-grid
   '((daily today require-timed)
     (800 1000 1200 1400 1600 1800 2000)
     " ┄┄┄┄┄ " "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
   org-agenda-current-time-string
   "◀── now ─────────────────────────────────────────────────"))

```

The `:ensure` for org-modern will need to be tweaked for your environment.