### PR TITLE
Fixed medium triangle unicode for fold-stars

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -66,7 +66,7 @@ Can be nil, fold or replace.  See `org-modern-fold-stars' and
   :type '(choice string (repeat string)))
 
 (defcustom org-modern-fold-stars
-  '(("▶" . "▼") ("▷" . "▽") ("⯈" . "⯆") ("▹" . "▿") ("▸" . "▾"))
+  '(("▶" . "▼") ("▷" . "▽") ("⏵" . "⏷") ("▹" . "▿") ("▸" . "▾"))
   "Folding indicators for headings.
 Replace headings' stars with an indicator showing whether its
 tree is folded or expanded."


### PR DESCRIPTION
Symbols ⯈ ,⯆ have now been replaced by their equivalent symbols ⏵ ⏷ in the function org-modern-fold-stars

The previous are not rendered even on the GitHub page
<img width="538" alt="image" src="https://github.com/user-attachments/assets/9b4d6874-843b-4be9-820d-66c7396a7a53" />
After fix,
<img width="538" alt="image" src="https://github.com/user-attachments/assets/2adc3d6f-6529-4bd5-a784-360b4d22a0bd" />
