### PR TITLE
Fix org-modern-agenda invalidating face-remap cookies held by other packages

### DIFF
--- a/org-modern.el
+++ b/org-modern.el
@@ -914,12 +914,17 @@ whole buffer; otherwise, for the line at point."
   (remove-from-invisibility-spec 'org-modern)
   (add-to-invisibility-spec 'org-modern) ;; Not idempotent?!
   (add-hook 'pre-redisplay-functions #'org-modern--pre-redisplay nil 'local)
-  (setq-local face-remapping-alist (copy-tree face-remapping-alist))
-  (maphash (lambda (face _spec)
-             (when (string-prefix-p "org-habit-" (symbol-name face))
-               (setf (alist-get face face-remapping-alist nil 'remove)
-                     (and org-modern-label-border `(org-modern-habit ,face)))))
-           face--new-frame-defaults)
+  (make-local-variable 'face-remapping-alist)
+  (setq face-remapping-alist
+        (cl-remove-if (lambda (e)
+                        (and (symbolp (car e))
+                             (string-prefix-p "org-habit-" (symbol-name (car e)))))
+                      face-remapping-alist))
+  (when org-modern-label-border
+    (maphash (lambda (face _spec)
+               (when (string-prefix-p "org-habit-" (symbol-name face))
+                 (push `(,face org-modern-habit ,face) face-remapping-alist)))
+             face--new-frame-defaults))
   (save-excursion
     (save-match-data
       (let (case-fold-search)


### PR DESCRIPTION
`org-modern-agenda` called `(setq-local face-remapping-alist (copy-tree face-remapping-alist))` to take ownership of the alist before modifying it with `setf/alist-get`. The problem is that `copy-tree` produces a structurally independent list with new cons cells, but any other package that called `face-remap-add-relative` holds a cookie that is a pointer into the _original_ cons cells. After the copy, those pointers are stale, and `face-remap-remove-relative` silently fails to find them, leaving the package's remapping permanently stuck in the buffer.

A visible symptom: when using `dimmer` and showing the `org-agenda` at startup, the `org-agenda` buffer appears permanently dimmed at startup, because dimmer's undim call (via its stale cookie) never takes effect.

This is a violation of the cooperative face remapping contract documented in the Emacs manual. `face-remap-add-relative` and `face-remap-remove-relative` are designed so multiple packages can independently manage remappings in the same buffer without interfering with each other.

Fix: replace the `copy-tree` + `setf` approach with the standard API. A buffer-local variable `org-modern--agenda-face-remaps` tracks the cookies returned by `face-remap-add-relative`. On each agenda refresh, the previous remappings are removed via those cookies before new ones are added, making the function idempotent and leaving other packages' entries untouched.